### PR TITLE
OCD-1899: Update tests to use new main-content ID

### DIFF
--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/CMSidReverseLookupPage.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/CMSidReverseLookupPage.java
@@ -56,7 +56,7 @@ public final class CMSidReverseLookupPage {
      * @return element holding main content
      */
     public static WebElement mainContent(final WebDriver driver) {
-        element = driver.findElement(By.id("mainContent"));
+        element = driver.findElement(By.id("main-content"));
         return element;
     }
     /**
@@ -65,7 +65,7 @@ public final class CMSidReverseLookupPage {
      * @return results section element
      */
     public static WebElement searchLookupResults(final WebDriver driver) {
-        element = driver.findElement(By.xpath("//*[@id=\"mainContent\"]/div[1]/div/div/div/div/span/button/i"));
+        element = driver.findElement(By.xpath("//*[@id=\"main-content\"]/div[1]/div/div/div/div/span/button/i"));
         return element;
     }
 

--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/ChplDownloadPage.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/ChplDownloadPage.java
@@ -117,7 +117,7 @@ public class ChplDownloadPage {
      * @return element holding main content
      */
     public static WebElement mainContent(final WebDriver driver) {
-        element = driver.findElement(By.id("mainContent"));
+        element = driver.findElement(By.id("main-content"));
         return element;
     }
 }

--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/CollectionsPages.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/CollectionsPages.java
@@ -25,7 +25,7 @@ public class CollectionsPages {
      * @return element holding main content
      */
     public static WebElement mainContent(final WebDriver driver) {
-        element = driver.findElement(By.id("mainContent"));
+        element = driver.findElement(By.id("main-content"));
         return element;
     }
 }

--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/ListingDetailsPage.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/ListingDetailsPage.java
@@ -77,7 +77,7 @@ public final class ListingDetailsPage {
      * @return the transparency disclosure URL
      */
     public static WebElement disclosureUrl(final WebDriver driver) {
-        element = driver.findElement(By.xpath("//*[@id=\"mainContent\"]/div[2]/div[1]/span/div[2]/a"));
+        element = driver.findElement(By.xpath("//*[@id=\"main-content\"]/div[2]/div[1]/span/div[2]/a"));
         return element;
     }
     /**
@@ -131,7 +131,7 @@ public final class ListingDetailsPage {
      * @return element holding main content
      */
     public static WebElement mainContent(final WebDriver driver) {
-        element = driver.findElement(By.id("mainContent"));
+        element = driver.findElement(By.id("main-content"));
         return element;
     }
     /**

--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/OverviewPage.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/OverviewPage.java
@@ -19,7 +19,7 @@ public final class OverviewPage {
      * @return element holding main content
      */
     public static WebElement mainContent(final WebDriver driver) {
-        element = driver.findElement(By.id("mainContent"));
+        element = driver.findElement(By.id("main-content"));
         return element;
     }
 


### PR DESCRIPTION
I don't like the page objects where there's a "mainContent" element, and another element that starts with the "mainContent" and goes down. I think it should start with the mainContent _element_, not the "by.id()" call, but not sure how to fix.