### PR TITLE
Fix Download page tests

### DIFF
--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/ChplDownloadPage.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/ChplDownloadPage.java
@@ -7,9 +7,8 @@ import org.openqa.selenium.WebElement;
 /**
  * Class ChplDownloadPage definition.
  */
-public class ChplDownloadPage {
-
-    private WebDriver driver;
+public final class ChplDownloadPage {
+    private ChplDownloadPage() {}
     private static WebElement element = null;
 
     /**
@@ -21,6 +20,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"definitionSelect\"]"));
         return element;
     }
+
     /**
      * Download files list(drop down) element.
      * @param driver WebDriver
@@ -30,6 +30,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id='downloadSelect']"));
         return element;
     }
+
     /**
      * Download files button element.
      * @param driver WebDriver
@@ -39,6 +40,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadChplLink\"]"));
         return element;
     }
+
     /**
      * Download definition files button element.
      * @param driver WebDriver
@@ -48,6 +50,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadChplDefinitionLink\"]"));
         return element;
     }
+
     /**
      * Download file - 2015 edition Products file element.
      * @param driver WebDriver
@@ -57,6 +60,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[1]"));
         return element;
     }
+
     /**
      * Download file - 2014 edition Products file element.
      * @param driver WebDriver
@@ -66,6 +70,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[2]"));
         return element;
     }
+
     /**
      * Download file - 2011 edition Products file element.
      * @param driver WebDriver
@@ -75,6 +80,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[3]"));
         return element;
     }
+
     /**
      * Download file - 2015 summary file element.
      * @param driver WebDriver
@@ -84,6 +90,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[4]"));
         return element;
     }
+
     /**
      * Download file - 2014 summary file element.
      * @param driver WebDriver
@@ -93,6 +100,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[5]"));
         return element;
     }
+
     /**
      * Download file - surveillance file element.
      * @param driver WebDriver
@@ -102,6 +110,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[6]"));
         return element;
     }
+
     /**
      * Download file - surveillance with non conformities file element.
      * @param driver WebDriver
@@ -111,6 +120,7 @@ public class ChplDownloadPage {
         element = driver.findElement(By.xpath("//*[@id=\"downloadSelect\"]/option[7]"));
         return element;
     }
+
     /**
      * Returns element holding main content.
      * @param driver WebDriver

--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/CollectionsPages.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/CollectionsPages.java
@@ -7,9 +7,10 @@ import org.openqa.selenium.WebElement;
 /**
  * Class CollectionsPages definition.
  */
-public class CollectionsPages {
-    private WebDriver driver;
+public final class CollectionsPages {
+    private CollectionsPages() {}
     private static WebElement element = null;
+
     /**
      * Returns ACB Filter button element.
      * @param driver WebDriver
@@ -19,6 +20,7 @@ public class CollectionsPages {
         element = driver.findElement(By.id("filter-button"));
         return element;
     }
+
     /**
      * Returns element holding main content.
      * @param driver WebDriver

--- a/src/test/java/gov/healthit/chpl/aqa/pageObjects/ComparePage.java
+++ b/src/test/java/gov/healthit/chpl/aqa/pageObjects/ComparePage.java
@@ -3,12 +3,14 @@ package gov.healthit.chpl.aqa.pageObjects;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
 /**
  * Class ComparePage definition.
  */
 public final class ComparePage {
     private ComparePage() {}
     private static WebElement element = null;
+
     /**
      * Toggle for widget display.
      * @param driver WebDriver
@@ -18,6 +20,7 @@ public final class ComparePage {
         element = driver.findElement(By.id("compare-widget-toggle"));
         return element;
     }
+
     /**
      * Get the button that navigates to compare page.
      * @param driver WebDriver

--- a/src/test/resources/Features/OCD-2023-monitorDownloadFiles.feature
+++ b/src/test/resources/Features/OCD-2023-monitorDownloadFiles.feature
@@ -1,35 +1,26 @@
 @Regression
-Feature: OCD-2023 - Monitor that download files on CHPL download resources page are correct and current
-  	Tests to verify download files show correct date on filenames to check file generation didn't fail at any point.
-Background: Download directory is empty
-  	Given I am on download the CHPL resources page
-  	And the download directory is empty
-  	
-  	Scenario: At any given time, when downloaded, 2015 edition products (xml) file is up-to-date  	
-  	When I download the 2015 edition products file 
-  	Then the downloaded file shows chpl-2015-currentdate.xml filename
-  	
-  	Scenario: At any given time, when downloaded, 2014 edition products (xml) file is up-to-date  	
-  	When I download the 2014 edition products file 
-  	Then the downloaded file shows chpl-2014-currentdate.xml filename
-  	
-  	Scenario: At any given time, when downloaded, 2011 edition products (xml) file is up-to-date as per schedule  	
-  	When I download the 2011 edition products file 
-  	Then the downloaded file shows 2011-chpl-lastrun.xml filename
-  	
-  	Scenario: At any given time, when downloaded, 2015 edition summary (csv) file is up-to-date  	
-  	When I download the 2015 edition summary file 
-  	Then the downloaded file shows chpl-2015-currentdate.csv filename
-  	
-  	Scenario: At any given time, when downloaded, 2014 edition summary (csv) file is up-to-date
-  	When I download the 2014 edition summary file 
-  	Then the downloaded file shows chpl-2014-currentdate.csv filename
-  	
-  	Scenario: At any given time, when downloaded, Surveillance Activity file is up-to-date  	
-  	When I download the Surveillance Activity file 
-  	Then the downloaded file shows surveillance-all.csv filename
-  	
-  	Scenario: At any given time, when downloaded, Non-Conformities file is up-to-date  	
-  	When I download the Non-Conformities file 
-  	Then the downloaded file shows surveillance-with-nonconformities.csv filename
-  	
+Feature: OCD-2023: Monitor that download files on CHPL download resources page are correct and current
+  Verify download files are recent, to ensure file generation didn't fail at any point.
+
+  Background: We need to start with an empty download directory, so that we can be sure we're checking the right file for recency.
+    Given I am on download the CHPL resources page
+    And the download directory is empty
+
+  Scenario Outline: The download files are "recent"
+    When I download the "<edition>" "<type>" products file
+    Then the downloaded file is no more than "<days>" days old
+    Examples:
+      | edition | type | days |
+      |    2011 | xml  |   92 |
+      |    2014 | xml  |    1 |
+      |    2014 | csv  |    1 |
+      |    2015 | xml  |    1 |
+      |    2015 | csv  |    1 |
+
+  Scenario: At any given time, when downloaded, Surveillance Activity file is up-to-date
+    When I download the Surveillance Activity file
+    Then the downloaded file shows surveillance-all.csv filename
+
+  Scenario: At any given time, when downloaded, Non-Conformities file is up-to-date
+    When I download the Non-Conformities file
+    Then the downloaded file shows surveillance-with-nonconformities.csv filename


### PR DESCRIPTION
The previous download tests asserted that a specific date was in the
filename for any given downloaded file. That doesn't really test the
requirement that a file be "recent", and has been failing on the 2011
edition as we had to manually build it recently. In addition, going
forward the 2011 file will be generated on the first Saturday of the
quartely month, which will only be on the first occasionally.