### PR TITLE
update test data to fix failing tests in CMS ID and surevillance search tests

### DIFF
--- a/src/test/resources/Features/OCD-2062-CMSIDsLookup.feature
+++ b/src/test/resources/Features/OCD-2062-CMSIDsLookup.feature
@@ -10,7 +10,7 @@ Feature: OCD-2062: Verify that newly generated & incorrectly removed CMS IDs sti
     Examples:
       | CMS_ID          | CHPL_ID                           |
       | 0015H8GK6K0ZZB2 | 14.07.07.2452.VEI1.01.01.0.161111 |
-      | 0015H8GK6K0ZZB2 | 15.04.04.2891.Sunr.07.01.1.171201 |
+      | 0015H8GK6K0ZZB2 | 15.04.04.2891.Sunr.07.02.1.171201 |
 
   Scenario Outline: Generating a CMS ID
     When I add "<CHPL_IDs>" Listings to the CMS Widget

--- a/src/test/resources/Features/OCD-2102-SearchSurveillanceListingsWithChplIDVersion.feature
+++ b/src/test/resources/Features/OCD-2102-SearchSurveillanceListingsWithChplIDVersion.feature
@@ -12,4 +12,4 @@ Scenario Outline: Verify surveillance search for a listing with CHPL ID version 
 Examples:
 	|CHPL_ID|
 	|15.04.04.2484.Updo.16.00.0.170720|
-	|15.04.04.2913.Gree.11.01.1.171101|
+	|15.04.04.2913.Gree.11.00.1.171101|


### PR DESCRIPTION
Edits by ACBs caused CHPL IDs to change (CHPL IDs were used as test data in two scripts).