### PR TITLE
OCD-2398-Verify the "basic information" product endpoint reports correct addl s/w code in CHPL ID

### DIFF
--- a/src/test/java/gov/healthit/chpl/aqa/RESTAssuredTests/VerifyEndpointHasCorrectData.java
+++ b/src/test/java/gov/healthit/chpl/aqa/RESTAssuredTests/VerifyEndpointHasCorrectData.java
@@ -14,8 +14,6 @@ import io.restassured.response.Response;
 public class VerifyEndpointHasCorrectData {
     private String url = System.getProperty("url");
     private String apikey = System.getProperty("apikey");
-    private String username = System.getProperty("username");
-    private String password = System.getProperty("password");
 
     /**
      * Set BaseUrl and other parameters.
@@ -28,12 +26,6 @@ public class VerifyEndpointHasCorrectData {
         if (StringUtils.isEmpty(apikey)) {
             throw new IllegalArgumentException("Missing value for apikey!");
         }
-        if (StringUtils.isEmpty(username)) {
-            throw new IllegalArgumentException("Missing value for username!");
-        }
-        if (StringUtils.isEmpty(password)) {
-            throw new IllegalArgumentException("Missing value for password!");
-        }
     }
 
     /**
@@ -43,18 +35,10 @@ public class VerifyEndpointHasCorrectData {
      */
     @Given("^I send request for product details using basic information product endpoint with \"([^\"]*)\" then I should get correct \"([^\"]*)\" in response$")
     public void validateResponseCP(final String dbId, final String chplId) {
-        Response token = given()
-                .header("API-KEY", apikey)
-                .header("content-type", "application/json")
-                .body("{\"userName\":\"" + username + "\",\"password\":\"" + password + "\"}")
-                .post(url + "/rest/auth/authenticate");
-        JsonPath jsonPathEvaluatorT = token.jsonPath();
-        String t1 = jsonPathEvaluatorT.get("token");
 
         Response response = given()
         .header("API-KEY", apikey)
         .header("content-type", "application/json")
-        .header("Authorization", "Bearer" + " " + t1)
         .get(url + "/rest/certified_products/" + dbId);
 
         // Get JsonPath object instance from the Response interface
@@ -69,7 +53,6 @@ public class VerifyEndpointHasCorrectData {
         Response responseDetail = given()
                 .header("API-KEY", apikey)
                 .header("content-type", "application/json")
-                .header("Authorization", "Bearer" + " " + t1)
                 .get(url + "/rest/certified_products/" + dbId + "/details");
 
                 JsonPath jsonPathEvaluator = responseDetail.jsonPath();

--- a/src/test/java/gov/healthit/chpl/aqa/RESTAssuredTests/VerifyEndpointHasCorrectData.java
+++ b/src/test/java/gov/healthit/chpl/aqa/RESTAssuredTests/VerifyEndpointHasCorrectData.java
@@ -1,0 +1,82 @@
+package gov.healthit.chpl.aqa.RESTAssuredTests;
+import static io.restassured.RestAssured.given;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testng.Assert;
+
+import cucumber.api.java.en.Given;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+
+/**
+ * Class VerifyEndpointHasCorrectData definition.
+ */
+public class VerifyEndpointHasCorrectData {
+    private String url = System.getProperty("url");
+    private String apikey = System.getProperty("apikey");
+    private String username = System.getProperty("username");
+    private String password = System.getProperty("password");
+
+    /**
+     * Set BaseUrl and other parameters.
+     */
+    public VerifyEndpointHasCorrectData() {
+
+        if (StringUtils.isEmpty(url)) {
+            url = "http://localhost:3000/";
+        }
+        if (StringUtils.isEmpty(apikey)) {
+            throw new IllegalArgumentException("Missing value for apikey!");
+        }
+        if (StringUtils.isEmpty(username)) {
+            throw new IllegalArgumentException("Missing value for username!");
+        }
+        if (StringUtils.isEmpty(password)) {
+            throw new IllegalArgumentException("Missing value for password!");
+        }
+    }
+
+    /**
+     * Runs API call requests using given endpoint to get certified product details and validate chpl Id in response.
+     * @param dbId is the database id of a listing to get listing details
+     * @param chplId is expected CHPL ID in response
+     */
+    @Given("^I send request for product details using basic information product endpoint with \"([^\"]*)\" then I should get correct \"([^\"]*)\" in response$")
+    public void validateResponseCP(final String dbId, final String chplId) {
+        Response token = given()
+                .header("API-KEY", apikey)
+                .header("content-type", "application/json")
+                .body("{\"userName\":\"" + username + "\",\"password\":\"" + password + "\"}")
+                .post(url + "/rest/auth/authenticate");
+        JsonPath jsonPathEvaluatorT = token.jsonPath();
+        String t1 = jsonPathEvaluatorT.get("token");
+
+        Response response = given()
+        .header("API-KEY", apikey)
+        .header("content-type", "application/json")
+        .header("Authorization", "Bearer" + " " + t1)
+        .get(url + "/rest/certified_products/" + dbId);
+
+        // Get JsonPath object instance from the Response interface
+        JsonPath jsonPathEvaluatorC = response.jsonPath();
+
+        // Get chplProductNumber from JSON response
+        String chplProductNumberInBasic = jsonPathEvaluatorC.get("chplProductNumber");
+
+        // Validate the response
+        Assert.assertEquals(chplProductNumberInBasic, chplId, "CHPL ID is as expected");
+
+        Response responseDetail = given()
+                .header("API-KEY", apikey)
+                .header("content-type", "application/json")
+                .header("Authorization", "Bearer" + " " + t1)
+                .get(url + "/rest/certified_products/" + dbId + "/details");
+
+                JsonPath jsonPathEvaluator = responseDetail.jsonPath();
+
+                String chplProductNumberInDetails = jsonPathEvaluator.get("chplProductNumber");
+
+                Assert.assertEquals(chplProductNumberInDetails, chplId, "CHPL ID is as expected");
+                Assert.assertEquals(chplProductNumberInBasic, chplProductNumberInDetails, "CHPL IDs match as expected");
+    }
+}

--- a/src/test/resources/Features/verifyEndpointsReturnCorrectResponse.feature
+++ b/src/test/resources/Features/verifyEndpointsReturnCorrectResponse.feature
@@ -1,0 +1,9 @@
+Feature: Verify endpoints return correct response 
+         OCD-2398- Verify the "basic information" product endpoint reports correct addl s/w code in CHPL ID
+         
+Scenario Outline: Test CP call
+When I send request for product details using basic information product endpoint with "<DB_ID>" then I should get correct "<CHPL_ID>" in response
+Examples:
+         |DB_ID|CHPL_ID|
+         |8252|15.04.04.2945.Ligh.21.00.1.161229| 
+             

--- a/src/test/resources/Features/verifyEndpointsReturnCorrectResponse.feature
+++ b/src/test/resources/Features/verifyEndpointsReturnCorrectResponse.feature
@@ -1,3 +1,4 @@
+@Regression
 Feature: Verify endpoints return correct response 
          OCD-2398- Verify the "basic information" product endpoint reports correct addl s/w code in CHPL ID
          

--- a/src/test/resources/Features/verifyEndpointsReturnCorrectResponse.feature
+++ b/src/test/resources/Features/verifyEndpointsReturnCorrectResponse.feature
@@ -2,9 +2,9 @@
 Feature: Verify endpoints return correct response 
          OCD-2398- Verify the "basic information" product endpoint reports correct addl s/w code in CHPL ID
          
-Scenario Outline: Test CP call
+Scenario Outline: Certified products basic information endpoint returns correct CHPL ID and current additional software code in CHPL ID
 When I send request for product details using basic information product endpoint with "<DB_ID>" then I should get correct "<CHPL_ID>" in response
 Examples:
          |DB_ID|CHPL_ID|
-         |8252|15.04.04.2945.Ligh.21.00.1.161229| 
+         |8252|15.04.04.2945.Ligh.21.00.1.161229|
              


### PR DESCRIPTION
I wrote it as one step scenario as breaking it down in steps wasn't working well with auth token and post requests in separate steps.