### PR TITLE
refactor: clean up some tests

### DIFF
--- a/src/test/java/gov/healthit/chpl/aqa/asserts/ChplAPIPageAsserts.java
+++ b/src/test/java/gov/healthit/chpl/aqa/asserts/ChplAPIPageAsserts.java
@@ -85,6 +85,7 @@ public class ChplAPIPageAsserts extends Base {
         File file = new File(getClass().getClassLoader().getResource(jsonFile).getFile());
         FileReader reader = new FileReader(file.getPath());
         Object notesObj = jsonParser.parse(reader);
+        reader.close();
         apiImplNoteList = (JSONArray) notesObj;
         for (Object object : apiImplNoteList) {
             failedCase = false;

--- a/src/test/java/gov/healthit/chpl/aqa/asserts/ChplSearchPageAsserts.java
+++ b/src/test/java/gov/healthit/chpl/aqa/asserts/ChplSearchPageAsserts.java
@@ -125,6 +125,7 @@ public class ChplSearchPageAsserts extends Base {
                 }
             }
             assertTrue(foundChpId, "chpl id [ " + chplId + " ] not found");
+            dataScanner.close();
             scanner.close();
         }
     }

--- a/src/test/java/gov/healthit/chpl/aqa/asserts/ViewVersionPageAsserts.java
+++ b/src/test/java/gov/healthit/chpl/aqa/asserts/ViewVersionPageAsserts.java
@@ -1,7 +1,7 @@
 package gov.healthit.chpl.aqa.asserts;
 
-import static org.junit.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -30,8 +30,7 @@ public class ViewVersionPageAsserts extends Base {
      */
     @Then("^I see edit link for version \"(.*)\"$")
     public void iSeeEditLinkToEditTheVersion(final String versionId) {
-        ViewVersionPage.editVersionLink(getDriver(), versionId).isDisplayed();
-        assertTrue(true);
+        assertTrue(ViewVersionPage.editVersionLink(getDriver(), versionId).isDisplayed());
     }
 
     /**
@@ -40,8 +39,7 @@ public class ViewVersionPageAsserts extends Base {
      */
     @Then("^I see merge link for version \"(.*)\"$")
     public void iSeeMergeLinkToMergeTheVersion(final String versionId) {
-        ViewVersionPage.mergeVersionLink(getDriver(), versionId).isDisplayed();
-        assertTrue(true);
+        assertTrue(ViewVersionPage.mergeVersionLink(getDriver(), versionId).isDisplayed());
     }
 
     /**

--- a/src/test/java/gov/healthit/chpl/aqa/stepDefinitions/CHPLResourcesDropdownSteps.java
+++ b/src/test/java/gov/healthit/chpl/aqa/stepDefinitions/CHPLResourcesDropdownSteps.java
@@ -1,6 +1,6 @@
 package gov.healthit.chpl.aqa.stepDefinitions;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import org.openqa.selenium.WebDriver;
 


### PR DESCRIPTION
[#testng]

Would like to fully remove junit, but the @RunWith thing needs to go too. Not sure how to do that. This question and answer are applicable: https://stackoverflow.com/questions/33916610/testng-runwith-from-junit